### PR TITLE
Update leaflet-loader.html

### DIFF
--- a/layouts/partials/leaflet-loader.html
+++ b/layouts/partials/leaflet-loader.html
@@ -1,9 +1,9 @@
 {{ range $.Site.Params.hugoLeaflet.css }}
-    <link rel="stylesheet" href="{{ .href }}" crossorigin="{{ .crossorigin }}" {{ range $key, $value := .params }} {{ $key | safeURL }}="{{ $value }}" {{ end }} />
+    <link rel="stylesheet" href="{{ .href | absURL }}" crossorigin="{{ .crossorigin }}" {{ range $key, $value := .params }} {{ $key | safeURL }}="{{ $value }}" {{ end }} />
 {{ end }}
 
 {{ range $.Site.Params.hugoLeaflet.js }}
-    <script src="{{ .src }}" crossorigin="{{ .crossorigin }}" {{ range $key, $value := .params }} {{ $key | safeURL }}="{{ $value }}" {{ end }} ></script>
+    <script src="{{ .src | absURL }}" crossorigin="{{ .crossorigin }}" {{ range $key, $value := .params }} {{ $key | safeURL }}="{{ $value }}" {{ end }} ></script>
 {{ end }}
 
 <style>


### PR DESCRIPTION
Disclaimer: This  is my first ever Pull request, please correct me if I am doing something wrong.

Currently, css and js of the leaflet submodule is loaded with respect to the page url. This fix makes it so that it always references to the `baseURL` + the parameter added in the `config.yaml`
