### PR TITLE
Fix imperial option in leaflet.elevation.js

### DIFF
--- a/static/js/leaflet.elevation.js
+++ b/static/js/leaflet.elevation.js
@@ -241,7 +241,7 @@ L.Control.Elevation = L.Control.extend({
         this._draggingEnabled = !L.Browser.mobile;
         this._chartEnabled = true;
 
-        if (options.imperial) {
+        if (this.options.imperial) {
             this._distanceFactor = this.__mileFactor;
             this._heightFactor = this.__footFactor;
             this._xLabel = "mi";


### PR DESCRIPTION
options.imperial seems to have no effect when the initialize function is ran unless referenced by this.options.imperial.